### PR TITLE
Add correct in_dim and out_dim in batch tensors (#8)

### DIFF
--- a/src/pyxir/runtime/backends/vai_rt/dpu_func.cpp
+++ b/src/pyxir/runtime/backends/vai_rt/dpu_func.cpp
@@ -155,14 +155,11 @@ void DpuFunc::operator()(
 
   for (ssize_t i = 0; i < in_tensor_names_.size(); ++i)
   {
-    batch_tensors.push_back(
-      std::shared_ptr<vitis::ai::Tensor>(
-        new vitis::ai::Tensor(dpu_runner_in_tensors_[i]->get_name(),
-                              dpu_runner_in_tensors_[i]->get_dims(),
-                              dpu_runner_in_tensors_[i]->get_data_type())
-      )
-    );
-
+    std::vector<std::int32_t> in_dims(in_tensors[i]->shape.begin(),
+                                      in_tensors[i]->shape.end());
+    batch_tensors.push_back(std::shared_ptr<vitis::ai::Tensor>(
+        new vitis::ai::Tensor(dpu_runner_in_tensors_[i]->get_name(), in_dims,
+                              dpu_runner_in_tensors_[i]->get_data_type())));
     inputs_cpu.push_back(
       vitis::ai::CpuFlatTensorBuffer(
         in_tensors[in_tensor_order_[i]]->data,
@@ -172,13 +169,11 @@ void DpuFunc::operator()(
 
   for (ssize_t i = 0; i < out_tensor_names_.size(); ++i)
   {
-    batch_tensors.push_back(
-      std::shared_ptr<vitis::ai::Tensor>(
-        new vitis::ai::Tensor(dpu_runner_out_tensors_[i]->get_name(),
-                              dpu_runner_out_tensors_[i]->get_dims(),
-                              dpu_runner_out_tensors_[i]->get_data_type())
-      )
-    );
+    std::vector<std::int32_t> out_dims(out_tensors[i]->shape.begin(),
+                                       out_tensors[i]->shape.end());
+    batch_tensors.push_back(std::shared_ptr<vitis::ai::Tensor>(
+        new vitis::ai::Tensor(dpu_runner_out_tensors_[i]->get_name(), out_dims,
+                              dpu_runner_out_tensors_[i]->get_data_type())));
     outputs_cpu.push_back(
       vitis::ai::CpuFlatTensorBuffer(
         out_tensors[out_tensor_order_[i]]->data,


### PR DESCRIPTION
Add correct in_dim and out_dim for batch tensors in Vitisi-AI runtime API for batch > 1 execution

Co-authored-by: Anil Martha <anil.martha@xilinx.com>
Co-authored-by: Jorn Tuyls <jornt@xilinx.com>